### PR TITLE
Crtitique

### DIFF
--- a/src/pages/GetStarted.js
+++ b/src/pages/GetStarted.js
@@ -99,7 +99,7 @@ export default class GetStarted extends Component {
             <List.Item as="li">
               Basically when you click "Submit" or "Add" in Distense you will
               get popup allowing you to adjust the Ethereum gas consumed and gas
-              price of each transaction. We suggest setting the gas price low,
+              price of each transaction (<a href="https://media.consensys.net/ethereum-gas-fuel-and-fees-3333e17fe1dc">What is Ethereum gas?</a>). We suggest setting the gas price low,
               to ~5 GWEI, as most Distense transactions are not time-sensitive.
               An exception is when you are submitting a pull request and are
               concerned about someone submitting one before you.


### PR DESCRIPTION
Response to issue #191.
Using Metamask section: add a link with information about gas for newbies.

When we follow the link to the task subsystem there are no tasks in there, thus I could not try the instructions or check the references (namely steps 3 in the last two sections).

The page could have a short introduction to distense at the top, linking to the "How it works" page. When in mobile the links for the get started sections (similar to what is done in 'how it works') would be useful.

The metamask icon when in mobile is not adjusted properly and covers a bit of text.